### PR TITLE
Cloud Agent：Docker-in-Docker 开发环境配置

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,55 @@
+# Cloud Agent base image for dsh-coding-subscription-oauth.
+# Canonical verification is Docker-in-Docker (`docker build --target check|verify`).
+# Nested Docker cannot use overlay2 here; vfs is required so `promote-release.mjs`
+# directory renames succeed (fuse-overlayfs hits ENOTEMPTY).
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    NVM_DIR=/home/ubuntu/.nvm \
+    PATH=/home/ubuntu/.nvm/versions/node/v22.19.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        iptables \
+        sudo \
+        fuse-overlayfs \
+    && install -m 0755 -d /etc/apt/keyrings \
+    && curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg \
+        | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu noble stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce=5:28.5.2-1~ubuntu.24.04~noble \
+        docker-ce-cli=5:28.5.2-1~ubuntu.24.04~noble \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
+    && update-alternatives --set iptables /usr/sbin/iptables-legacy \
+    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy \
+    && mkdir -p /etc/docker \
+    && printf '%s\n' '{' '  "storage-driver": "vfs"' '}' > /etc/docker/daemon.json \
+    && useradd -m -s /bin/bash -u 1000 ubuntu \
+    && echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ubuntu \
+    && chmod 0440 /etc/sudoers.d/ubuntu \
+    && usermod -aG docker ubuntu \
+    && rm -rf /var/lib/apt/lists/*
+
+USER ubuntu
+WORKDIR /home/ubuntu
+
+RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install 22.19.0 \
+    && nvm alias default 22.19.0 \
+    && corepack enable \
+    && corepack prepare pnpm@11.21.0 --activate \
+    && node --version \
+    && pnpm --version
+
+USER ubuntu

--- a/.cursor/ensure-dockerd.sh
+++ b/.cursor/ensure-dockerd.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Start dockerd for nested Docker builds. Idempotent; returns after readiness.
+set -euo pipefail
+
+if docker info >/dev/null 2>&1; then
+	exit 0
+fi
+
+if [[ ! -f /etc/docker/daemon.json ]]; then
+	sudo mkdir -p /etc/docker
+	# vfs: fuse-overlayfs breaks promote-release.mjs directory rename (ENOTEMPTY)
+	printf '%s\n' '{' '  "storage-driver": "vfs"' '}' | sudo tee /etc/docker/daemon.json >/dev/null
+fi
+
+if ! pgrep -x dockerd >/dev/null 2>&1; then
+	sudo dockerd >/tmp/dockerd.log 2>&1 &
+fi
+
+for _ in $(seq 1 40); do
+	if [[ -S /var/run/docker.sock ]]; then
+		sudo chmod 666 /var/run/docker.sock || true
+	fi
+	if docker info >/dev/null 2>&1; then
+		exit 0
+	fi
+	sleep 1
+done
+
+echo "error: dockerd failed to become ready" >&2
+tail -n 50 /tmp/dockerd.log >&2 || true
+exit 1

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,10 @@
+{
+  "name": "dsh-coding-subscription-oauth",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "user": "ubuntu",
+  "install": "true",
+  "start": "bash .cursor/ensure-dockerd.sh"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

为 Cloud Agent 增加仓库内环境配置，使后续 agent 能按 `CONTRIBUTING.md` 约定在隔离 Docker sandbox 中跑 `check` / `verify`。

## Changes

- `.cursor/Dockerfile`：Ubuntu 24.04 + Docker CE 28.5.2（`vfs` 存储驱动）+ Node 22.19.0 + pnpm 11.21.0
- `.cursor/environment.json`：`install: true`，`start` 启动 dockerd
- `.cursor/ensure-dockerd.sh`：幂等启动 dockerd 并等待就绪

## Why `vfs`

Cloud Agent 嵌套 Docker 不支持 `overlay2`；`fuse-overlayfs` 会导致 `build/promote-release.mjs` 目录 `rename` 报 `ENOTEMPTY`。`vfs` 虽较慢，但可完整通过 `check` / `verify` / `isolated-install`。

## Validation (setup agent VM)

| Check | Result |
| --- | --- |
| `docker build --target check` | Pass（biome + release:build + **422** vitest） |
| `docker build --target verify` | Pass（+ preview-proxy tests + lib drift + release:dry） |
| `docker build --target isolated-install` | Pass（pack → import plugin → CLI `--help` / `status all`） |
| install idempotence (`true`) | Pass twice |
| `ensure-dockerd.sh` | Pass twice |
| Draft build `bld-20260817-c242533f-0d96-4bd2-aab6-e71fcd0b5aa8` | SUCCEEDED（promotable, default refs, `install: true`） |
| Fresh agent on that build | Confirmed install OK; Docker absent on default base（预期，需合并本 PR 后由 `.cursor/Dockerfile` 提供） |

## Hello-world evidence

[hello_world_cli.log](https://cursor.com/agents/bc-8db202a5-8911-484d-beca-2758f11513c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_cli.log)

实际为文本日志（CLI 演示）：

[hello_world_cli.log](https://cursor.com/agents/bc-8db202a5-8911-484d-beca-2758f11513c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_cli.log)

[env_validation_summary.log](https://cursor.com/agents/bc-8db202a5-8911-484d-beca-2758f11513c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_validation_summary.log)

## Notes

- 本仓库不是独立 Web 应用；规范验证路径是 Docker `check`/`verify`，不是 host 上直接 `pnpm install`。
- 交互式 UI 预览仍需 `docker/run-preview.sh` + 外部 `DSH_INSTALL_DIR`（可选）。
- 合并本 PR 后，新 agent 会读仓库内 `.cursor/environment.json`（含 Dockerfile），再在 Environment 面板 Save。

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8db202a5-8911-484d-beca-2758f11513c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8db202a5-8911-484d-beca-2758f11513c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

