### PR TITLE
fix: release lib promotion across overlayfs / EXDEV

### DIFF
--- a/build/promote-release.mjs
+++ b/build/promote-release.mjs
@@ -27,6 +27,17 @@ async function collectFiles(from, relative = "") {
 	return out;
 }
 
+/** Atomic when possible; fall back to copy+remove across devices (EXDEV / overlayfs). */
+async function movePath(from, to) {
+	try {
+		await rename(from, to);
+	} catch (error) {
+		if (error?.code !== "EXDEV") throw error;
+		await cp(from, to, { recursive: true, force: true });
+		await rm(from, { recursive: true, force: true });
+	}
+}
+
 // Keep bundled runtime files plus every .d.ts/.d.ts.map emitted by tsc; skip
 // intermediate .js/.js.map from the declaration step and esbuild intermediates.
 const wanted = [];
@@ -58,22 +69,22 @@ for (const name of wanted) {
 
 let replacedExisting = false;
 try {
-	await rename(target, backup);
+	await movePath(target, backup);
 	replacedExisting = true;
 } catch (error) {
 	if (error?.code !== "ENOENT") throw error;
 }
 try {
-	await rename(staging, target);
+	await movePath(staging, target);
 } catch (error) {
-	if (replacedExisting) await rename(backup, target);
+	if (replacedExisting) await movePath(backup, target);
 	throw error;
 }
 try {
 	await import(`./verify-release.mjs?promotion=${Date.now()}`);
 } catch (error) {
 	await rm(target, { recursive: true, force: true });
-	if (replacedExisting) await rename(backup, target);
+	if (replacedExisting) await movePath(backup, target);
 	throw error;
 }
 await rm(backup, { recursive: true, force: true });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`build/promote-release.mjs` used `fs.rename` to swap `lib/` during `release:build`. On Cloud Agent / overlayfs checkouts, renaming the tracked `lib/` directory fails with `EXDEV: cross-device link not permitted`, so `pnpm run check` never completes.

## Change

- Add `movePath()` that prefers `rename`, and on `EXDEV` falls back to recursive `cp` + `rm`
- Use it for promote, rollback, and restore paths

## Test plan

- [x] Reproduce `rename('lib', backup)` → `EXDEV`
- [x] Confirm `cp` + `rm` round-trip restores `lib/`
- [x] `pnpm run check` passes in Cloud Agent workspace (lint + release:build + 422 tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f74f71b-60a5-4217-8550-9bb9ccafc513?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f74f71b-60a5-4217-8550-9bb9ccafc513&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

