### PR TITLE
docs: drop deleted dsh-grok-build GitHub install path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `dsh-coding-subscription-oauth` are documented here, foll
 
 ## Unreleased
 
+### Documentation
+
+- Record that the legacy GitHub repository `dsh-grok-build` has been removed; install only via `dsh-coding-subscription-oauth` (npm or the current GitHub URL). Runtime CLI alias and `/plugins/dsh-grok-build/*` paths stay compatible.
+
 ## v0.5.2 - 2026-08-18
 
 ### Documentation

--- a/README.de.md
+++ b/README.de.md
@@ -23,7 +23,7 @@ Zuerst **`dsh-grok-build`** (nur Grok Build). Jetzt SuperGrok / Codex / Kimi / C
 
 | | Das verwenden | Funktioniert weiter |
 |---|---|---|
-| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `github:lninghaha/dsh-grok-build` (derselbe `main`) |
+| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | Altes GitHub-Repo `dsh-grok-build` entfernt |
 | npm | `dsh-coding-subscription-oauth@0.5.2` (aktuelle Version) | Es gab kein altes npm-Paket |
 | CLI | `dsh-coding-oauth` | `dsh-grok-build` |
 | Cordis-Plugin-id | `llm-grok-build-oauth` | unverändert |

--- a/README.es.md
+++ b/README.es.md
@@ -23,7 +23,7 @@ Empezó como **`dsh-grok-build`** (solo Grok Build). Ahora cubre SuperGrok / Cod
 
 | | Usa esto | Sigue funcionando |
 |---|---|---|
-| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `github:lninghaha/dsh-grok-build` (el mismo `main`) |
+| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | El repo GitHub antiguo `dsh-grok-build` fue eliminado |
 | npm | `dsh-coding-subscription-oauth@0.5.2` (versión actual) | No se publicó un paquete npm legado |
 | CLI | `dsh-coding-oauth` | `dsh-grok-build` |
 | Cordis plugin id | `llm-grok-build-oauth` | sin cambios |

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,7 +23,7 @@ Le projet s'appelait **`dsh-grok-build`** (Grok Build uniquement). Il couvre mai
 
 | | Utiliser | Toujours valable |
 |---|---|---|
-| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `github:lninghaha/dsh-grok-build` (même `main`) |
+| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | Ancien dépôt GitHub `dsh-grok-build` supprimé |
 | npm | `dsh-coding-subscription-oauth@0.5.2` (version actuelle) | Aucun ancien paquet npm n'a été publié |
 | CLI | `dsh-coding-oauth` | `dsh-grok-build` |
 | Cordis plugin id | `llm-grok-build-oauth` | inchangé |

--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@
 
 | | これを使う | 互換 |
 |---|---|---|
-| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `github:lninghaha/dsh-grok-build`（同じ `main`） |
+| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | 旧 GitHub リポジトリ `dsh-grok-build` は削除済み |
 | npm | `dsh-coding-subscription-oauth@0.5.2`（現在のリリース） | 旧 npm パッケージは公開されていない |
 | CLI | `dsh-coding-oauth` | `dsh-grok-build` |
 | Cordis プラグイン id | `llm-grok-build-oauth` | 変更なし |

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
 
 | | 이것을 쓰세요 | 계속 동작 |
 |---|---|---|
-| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `github:lninghaha/dsh-grok-build`（같은 `main`） |
+| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | 이전 GitHub 저장소 `dsh-grok-build` 는 삭제됨 |
 | npm | `dsh-coding-subscription-oauth@0.5.2`（현재 릴리스） | 레거시 npm 패키지는 게시된 적 없음 |
 | CLI | `dsh-coding-oauth` | `dsh-grok-build` |
 | Cordis 플러그인 id | `llm-grok-build-oauth` | 그대로 |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -23,7 +23,7 @@ O projeto começou como **`dsh-grok-build`** (só Grok Build). Agora cobre Super
 
 | | Use isto | Ainda funciona |
 |---|---|---|
-| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `github:lninghaha/dsh-grok-build` (mesmo `main`) |
+| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | Repositório GitHub antigo `dsh-grok-build` removido |
 | npm | `dsh-coding-subscription-oauth@0.5.2` (versão atual) | Nenhum pacote npm legado foi publicado |
 | CLI | `dsh-coding-oauth` | `dsh-grok-build` |
 | Cordis plugin id | `llm-grok-build-oauth` | inalterado |

--- a/README.ru.md
+++ b/README.ru.md
@@ -23,7 +23,7 @@
 
 | | Используйте | По-прежнему работает |
 |---|---|---|
-| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | `github:lninghaha/dsh-grok-build` (тот же `main`) |
+| GitHub / `dsh plugin add` | [`dsh-coding-subscription-oauth`](https://github.com/lninghaha/dsh-coding-subscription-oauth) | Старый GitHub-репозиторий `dsh-grok-build` удалён |
 | npm | `dsh-coding-subscription-oauth@0.5.2` (текущая версия) | Старого npm-пакета не было |
 | CLI | `dsh-coding-oauth` | `dsh-grok-build` |
 | Cordis plugin id | `llm-grok-build-oauth` | без изменений |

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -118,7 +118,7 @@ This project does not replicate the private Google Antigravity protocol. The pro
 
 ## 6. Compatibility
 
-The canonical package and repository name is **`dsh-coding-subscription-oauth`**. The previous GitHub URL still resolves to the same `main`, so old `dsh plugin add github:lninghaha/dsh-grok-build` commands continue to install the renamed package. The first public npm/GitHub Release was **`0.4.1`**. The current release is **`0.5.2`** (`dsh plugin --profile web add dsh-coding-subscription-oauth@0.5.2`). GitHub and local tarball installs remain valid.
+The canonical package and repository name is **`dsh-coding-subscription-oauth`**. The previous GitHub repository `dsh-grok-build` has been removed; install only via the current name (npm or `github:lninghaha/dsh-coding-subscription-oauth`). The first public npm/GitHub Release was **`0.4.1`**. The current release is **`0.5.2`** (`dsh plugin --profile web add dsh-coding-subscription-oauth@0.5.2`). GitHub and local tarball installs of the current repository remain valid.
 
 Stable on-disk / in-process identifiers (do not rename without a migration):
 

--- a/docs/02-architecture.zh-CN.md
+++ b/docs/02-architecture.zh-CN.md
@@ -118,7 +118,7 @@ POST   /plugins/dsh-grok-build/gateway/rotate
 
 ## 6. 兼容性
 
-正式包名与仓库名是 **`dsh-coding-subscription-oauth`**。旧 GitHub 地址仍指向同一条 `main`，因此旧的 `dsh plugin add github:lninghaha/dsh-grok-build` 仍会安装更名后的包。第一次公开 npm / GitHub Release 是 **`0.4.1`**。当前版本是 **`0.5.2`**（`dsh plugin --profile web add dsh-coding-subscription-oauth@0.5.2`）。GitHub 与本地 tarball 安装仍然有效。
+正式包名与仓库名是 **`dsh-coding-subscription-oauth`**。旧 GitHub 仓库 `dsh-grok-build` 已删除；请只通过现名安装（npm 或 `github:lninghaha/dsh-coding-subscription-oauth`）。第一次公开 npm / GitHub Release 是 **`0.4.1`**。当前版本是 **`0.5.2`**（`dsh plugin --profile web add dsh-coding-subscription-oauth@0.5.2`）。当前仓库的 GitHub 与本地 tarball 安装仍然有效。
 
 以下标识保持稳定（无迁移方案前不要改名）：
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

旧 GitHub 仓库 `dsh-grok-build` 已删除（404）。本 PR 收口文档，不再宣称旧 `github:lninghaha/dsh-grok-build` 安装路径仍可用或仍跟踪同一条 `main`；安装只通过现名（npm 或 `github:lninghaha/dsh-coding-subscription-oauth`）。

## Changes

- 七种社区语言 README（ja/ko/pt-BR/es/fr/de/ru）Name change 表 GitHub 行改为「旧仓已删除」
- `docs/02-architecture.md` / `.zh-CN.md` 兼容性段落同步更新
- `CHANGELOG.md` `## Unreleased` 补充 Documentation 记录

## Not changed (runtime compat)

保留 Cordis id `llm-grok-build-oauth`、HTTP `/plugins/dsh-grok-build/*`、CLI 别名 `dsh-grok-build`、凭据路径与 LLM routes；「formerly / 原名」历史表述保留。

## Already on main

`README.md`、`README.zh-CN.md`、`INSTALL.md` 此前已更新；`INSTALL.md` 仍以「# 安装与使用」开头。

## Verification

- `rg 'github:lninghaha/dsh-grok-build'` 在目标文档中为 0
- 运行时兼容说明仍在 EN/ZH README 与架构文档中

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38de0ccc-cc2a-4b17-ab47-ef64de98b7a1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38de0ccc-cc2a-4b17-ab47-ef64de98b7a1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

