### PR TITLE
chore: 忽略本地 AGENTS.md，避免同步到公开仓库

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ ccr/
 
 # local-only fault-investigation probe (never commit)
 scripts/probe-proxy-interception.mjs
+
+# Cloud-agent local instructions (personal environment injects this file;
+# never sync to the public repository)
+AGENTS.md


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `.gitignore` 增加 `AGENTS.md`，确保云代理本地发布规则文件不会进入公开仓库。
- `AGENTS.md` 本身仅存在于个人云环境本地（由 Environment install 注入），不随 git 同步。

## Test plan

- [x] `git check-ignore -v AGENTS.md` 命中 ignore 规则
- [x] `git status` 不显示 `AGENTS.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4244926a-dbd5-4bd3-b12f-ddd0e77b170d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4244926a-dbd5-4bd3-b12f-ddd0e77b170d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

