### PR TITLE
docs: fix 0.6.3 upgrade attribution and any-model boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `dsh-coding-subscription-oauth` are documented here, foll
 
 ## Unreleased
 
+### Documentation
+
+- Correct the README upgrade callout so Cordis/DSH `0.1.1-rc.2` support is attributed to `0.6.2+`, and name `0.6.3` for default-off `codexImagesAnyModel`; add the any-model route-gate boundary sentence across README translations and an `INSTALL.md` `0.6.2` → `0.6.3` upgrade note.
+
 ## v0.6.3 - 2026-08-28
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,6 +44,7 @@ dsh plugin --profile web add dsh-agy@0.1.2
 
 - 本版按 DSH `0.1.1-rc.2` 的精确兼容矩阵发布；生产环境应锁定已验证的 BOM，不要用 `*` 或未验证的宽泛 peer range。
 - 从 `0.6.0` 升级到 `0.6.2` 后再重启：`0.6.0` 在严格 Cordis 注入检查下可能因读取尚未注入的可选服务而拖垮插件树。这个补丁不迁移或重置 OAuth 凭据、Gateway、模型/适配器 ID 与缓存。
+- 从 `0.6.2` 升级到 `0.6.3`：新增默认关闭的 `codexImagesAnyModel`（仅放宽调用模型路由门禁；无凭据迁移）。
 - 在同一个 **web profile** 中先保证 `dsh-coding-oauth-core@0.1.0` 可从 npm 解析，再安装 Subscription `0.6.3`（以及需要的 `dsh-hub-oauth-gateway@1.10.0`）。Core 只是共享 npm 依赖，不是单独的 DSH 插件，用户不需要执行 `dsh plugin add dsh-coding-oauth-core`。
 - 共装 Hub 与 Subscription 时，先安装 `dsh-hub-oauth-gateway@1.10.0` 与 Subscription `0.6.3`，完成后只重启一次现有 DSH Web 进程；Hub 提供完整用量中心，Subscription 显示紧凑状态入口。只升级 Subscription 仍可独立工作。
 - 升级会保留既有 Cordis id、OAuth 凭据文件、模型/适配器 ID、Gateway 配置和模型缓存；不要为了“清理旧版本”删除这些文件。若旧包名 `dsh-grok-build` 仍在 profile 中，只移除那条旧插件记录，再安装当前包，避免重复路由。

--- a/README.de.md
+++ b/README.de.md
@@ -177,7 +177,7 @@ Der Wähler listet nur Routen, die die Authentifizierung abgeschlossen haben; ni
 
 ## Optionale Funktionen
 
-Die acht Schalter `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` und `grokImagineVideo` sind standardmäßig aus und werden ohne Neustart live angewendet. Die Grenzwerte sind `searchResults` (1–20, Standard 5), `imageCount` (1–4, Standard 1) und `videoArtifactTtlMs` (1 Stunde–7 Tage, Standard 7 Tage; die Oberfläche zeigt 1–168 Stunden). Eine kürzere Aufbewahrung verkürzt und bereinigt vorhandene Artefakte sofort; eine Erhöhung gilt nur für neue Artefakte.
+Die acht Schalter `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` und `grokImagineVideo` sind standardmäßig aus und werden ohne Neustart live angewendet. `codexImagesAnyModel` lockert nur die Aufrufmodell-Routenbeschränkung; weiterhin erforderlich sind angemeldetes Codex, `codexImages` (und der Edits-Schalter für Bearbeitung) sowie Sitzungs-Anhangbesitz und Bearbeitungsautorisierung. Die Grenzwerte sind `searchResults` (1–20, Standard 5), `imageCount` (1–4, Standard 1) und `videoArtifactTtlMs` (1 Stunde–7 Tage, Standard 7 Tage; die Oberfläche zeigt 1–168 Stunden). Eine kürzere Aufbewahrung verkürzt und bereinigt vorhandene Artefakte sofort; eine Erhöhung gilt nur für neue Artefakte.
 
 ## Lokales API-Gateway
 

--- a/README.es.md
+++ b/README.es.md
@@ -178,7 +178,7 @@ El selector solo lista rutas que completaron la autenticación; los proveedores 
 
 ## Capacidades opcionales
 
-Los ocho controles `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` y `grokImagineVideo` empiezan desactivados y se aplican en vivo, sin reinicio. Los límites son `searchResults` (1–20, predeterminado 5), `imageCount` (1–4, predeterminado 1) y `videoArtifactTtlMs` (1 hora–7 días, predeterminado 7 días; la interfaz muestra 1–168 horas). Reducir la retención acorta y limpia los artefactos existentes de inmediato; aumentarla solo afecta a los nuevos.
+Los ocho controles `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` y `grokImagineVideo` empiezan desactivados y se aplican en vivo, sin reinicio. `codexImagesAnyModel` solo relaja la restricción de ruta del modelo que llama; sigue exigiendo Codex con sesión iniciada, `codexImages` (y el interruptor de ediciones para editar) y conserva la propiedad de adjuntos de la sesión y la autorización de edición. Los límites son `searchResults` (1–20, predeterminado 5), `imageCount` (1–4, predeterminado 1) y `videoArtifactTtlMs` (1 hora–7 días, predeterminado 7 días; la interfaz muestra 1–168 horas). Reducir la retención acorta y limpia los artefactos existentes de inmediato; aumentarla solo afecta a los nuevos.
 
 ## Gateway de API local
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -178,7 +178,7 @@ Le sélecteur ne liste que les routes ayant terminé l'authentification ; les fo
 
 ## Capacités optionnelles
 
-Les huit options `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` et `grokImagineVideo` sont désactivées par défaut et s'appliquent à chaud, sans redémarrage. Les limites sont `searchResults` (1–20, défaut 5), `imageCount` (1–4, défaut 1) et `videoArtifactTtlMs` (1 heure–7 jours, défaut 7 jours ; l'interface affiche 1–168 heures). Réduire la rétention raccourcit et nettoie immédiatement les artefacts existants ; l'augmenter ne concerne que les nouveaux.
+Les huit options `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` et `grokImagineVideo` sont désactivées par défaut et s'appliquent à chaud, sans redémarrage. `codexImagesAnyModel` ne relâche que la contrainte de route du modèle appelant ; Codex connecté, `codexImages` (et le commutateur d'édition pour éditer), ainsi que la propriété des pièces jointes de session et l'autorisation d'édition restent requis. Les limites sont `searchResults` (1–20, défaut 5), `imageCount` (1–4, défaut 1) et `videoArtifactTtlMs` (1 heure–7 jours, défaut 7 jours ; l'interface affiche 1–168 heures). Réduire la rétention raccourcit et nettoie immédiatement les artefacts existants ; l'augmenter ne concerne que les nouveaux.
 
 ## Passerelle API locale
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -178,7 +178,7 @@ pnpm run smoke:deployed             # 実際の Codex/Kimi ツール呼び出し
 
 ## オプション機能
 
-8 つのスイッチ `codexSearch`、`codexImages`、`codexImageEdits`、`codexImagesAnyModel`、`codexUsage`、`codexFast`、`grokImagineImage`、`grokImagineVideo` はすべて既定でオフで、変更は再起動なしで反映されます。数値設定は `searchResults`（1–20、既定 5）、`imageCount`（1–4、既定 1）、`videoArtifactTtlMs`（1 時間–7 日、既定 7 日、UI は 1–168 時間）です。保持期間を短くすると既存の成果物も直ちに短縮・削除され、長くした場合は以後の成果物にのみ適用されます。
+8 つのスイッチ `codexSearch`、`codexImages`、`codexImageEdits`、`codexImagesAnyModel`、`codexUsage`、`codexFast`、`grokImagineImage`、`grokImagineVideo` はすべて既定でオフで、変更は再起動なしで反映されます。`codexImagesAnyModel` は呼び出しモデルのルート制限のみを緩和します。引き続き Codex へのサインイン、`codexImages`（編集時は edits フラグ）、セッション添付の所有権と編集認可が必要です。数値設定は `searchResults`（1–20、既定 5）、`imageCount`（1–4、既定 1）、`videoArtifactTtlMs`（1 時間–7 日、既定 7 日、UI は 1–168 時間）です。保持期間を短くすると既存の成果物も直ちに短縮・削除され、長くした場合は以後の成果物にのみ適用されます。
 
 ## ローカル API ゲートウェイ
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -178,7 +178,7 @@ pnpm run smoke:deployed             # 실제 Codex/Kimi 도구 호출 + 두 번�
 
 ## 선택적 기능
 
-8개 스위치 `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage`, `grokImagineVideo`는 모두 기본적으로 꺼져 있으며 재시작 없이 즉시 적용됩니다. 숫자 설정은 `searchResults`(1–20, 기본 5), `imageCount`(1–4, 기본 1), `videoArtifactTtlMs`(1시간–7일, 기본 7일, UI에서는 1–168시간)입니다. 보존 시간을 낮추면 기존 아티팩트도 즉시 단축·정리되며, 높인 값은 이후 생성된 아티팩트에만 적용됩니다.
+8개 스위치 `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage`, `grokImagineVideo`는 모두 기본적으로 꺼져 있으며 재시작 없이 즉시 적용됩니다. `codexImagesAnyModel`은 호출 모델 라우트 게이트만 완화합니다. 여전히 Codex 로그인, `codexImages`(편집 시 edits 플래그), 세션 첨부 소유권 및 편집 인가가 필요합니다. 숫자 설정은 `searchResults`(1–20, 기본 5), `imageCount`(1–4, 기본 1), `videoArtifactTtlMs`(1시간–7일, 기본 7일, UI에서는 1–168시간)입니다. 보존 시간을 낮추면 기존 아티팩트도 즉시 단축·정리되며, 높인 값은 이후 생성된 아티팩트에만 적용됩니다.
 
 ## 로컬 API 게이트웨이
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ---
 
-> **Upgrade / 升级：** Follow the versioned steps in [`INSTALL.md`](INSTALL.md). `0.6.3` includes the strict Cordis injection startup fix and DSH `0.1.1-rc.2` support; keep profile/config/credential files and restart one existing DSH Web process only after updating. `dsh-coding-oauth-core@0.1.0` remains a shared npm dependency, not a separate DSH plugin.
+> **Upgrade / 升级：** Follow the versioned steps in [`INSTALL.md`](INSTALL.md). `0.6.3` adds the default-off `codexImagesAnyModel` switch. Releases from `0.6.2` onward include the strict Cordis injection startup fix and DSH `0.1.1-rc.2` support; keep profile/config/credential files and restart one existing DSH Web process only after updating. `dsh-coding-oauth-core@0.1.0` remains a shared npm dependency, not a separate DSH plugin.
 
 ---
 
@@ -184,7 +184,7 @@ The selector only lists routes that completed authentication; unauthenticated pr
 
 ## Optional capabilities
 
-All eight switches start **off** and apply **live** (no restart): `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage`, and `grokImagineVideo`. Numeric controls are `searchResults` (1–20, default 5), `imageCount` (1–4, default 1), and `videoArtifactTtlMs` (1 hour–7 days, default 7 days; the UI shows 1–168 hours). Lowering video retention shortens and cleans existing artifacts immediately; raising it affects only artifacts created afterward. Administrators may provide secret-free composition defaults under plugin config `capabilities`; live user settings in the `coding-subscription-oauth` settings section override that base, and omitting it keeps every switch off.
+All eight switches start **off** and apply **live** (no restart): `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage`, and `grokImagineVideo`. `codexImagesAnyModel` only relaxes the calling-model route gate; it still requires signed-in Codex, `codexImages` (and the edits flag for edit), and keeps session attachment ownership and edit authorization. Numeric controls are `searchResults` (1–20, default 5), `imageCount` (1–4, default 1), and `videoArtifactTtlMs` (1 hour–7 days, default 7 days; the UI shows 1–168 hours). Lowering video retention shortens and cleans existing artifacts immediately; raising it affects only artifacts created afterward. Administrators may provide secret-free composition defaults under plugin config `capabilities`; live user settings in the `coding-subscription-oauth` settings section override that base, and omitting it keeps every switch off.
 
 `codex-oauth-fast` is advertised only after a **fresh live catalog** lists at least one `priority`-eligible model. Those requests send `service_tier: priority` plus a routing hint. The UI says **Fast requested** and never guarantees latency or that upstream will honor the request.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -178,7 +178,7 @@ O seletor lista apenas rotas que concluíram a autenticação; provedores não a
 
 ## Capacidades opcionais
 
-Os oito controles `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` e `grokImagineVideo` começam desativados e mudam ao vivo, sem reinício. Os limites são `searchResults` (1–20, padrão 5), `imageCount` (1–4, padrão 1) e `videoArtifactTtlMs` (1 hora–7 dias, padrão 7 dias; a interface mostra 1–168 horas). Reduzir a retenção encurta e limpa artefatos existentes imediatamente; aumentá-la vale apenas para novos artefatos.
+Os oito controles `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` e `grokImagineVideo` começam desativados e mudam ao vivo, sem reinício. `codexImagesAnyModel` só afrouxa o gate de rota do modelo que chama; ainda exige Codex autenticado, `codexImages` (e o flag de edits para editar) e mantém a propriedade de anexos da sessão e a autorização de edição. Os limites são `searchResults` (1–20, padrão 5), `imageCount` (1–4, padrão 1) e `videoArtifactTtlMs` (1 hora–7 dias, padrão 7 dias; a interface mostra 1–168 horas). Reduzir a retenção encurta e limpa artefatos existentes imediatamente; aumentá-la vale apenas para novos artefatos.
 
 ## Gateway de API local
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -178,7 +178,7 @@ pnpm run smoke:deployed             # реальные вызовы Codex/Kimi +
 
 ## Дополнительные возможности
 
-Все восемь переключателей `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` и `grokImagineVideo` по умолчанию выключены и применяются без перезапуска. Ограничения: `searchResults` (1–20, по умолчанию 5), `imageCount` (1–4, по умолчанию 1) и `videoArtifactTtlMs` (1 час–7 дней, по умолчанию 7 дней; в интерфейсе 1–168 часов). Уменьшение срока сразу сокращает и очищает существующие артефакты; увеличение действует только на новые.
+Все восемь переключателей `codexSearch`, `codexImages`, `codexImageEdits`, `codexImagesAnyModel`, `codexUsage`, `codexFast`, `grokImagineImage` и `grokImagineVideo` по умолчанию выключены и применяются без перезапуска. `codexImagesAnyModel` лишь ослабляет ограничение маршрута вызывающей модели; по-прежнему нужны вход в Codex, `codexImages` (и флаг edits для редактирования), а также сохраняются владение вложениями сессии и авторизация редактирования. Ограничения: `searchResults` (1–20, по умолчанию 5), `imageCount` (1–4, по умолчанию 1) и `videoArtifactTtlMs` (1 час–7 дней, по умолчанию 7 дней; в интерфейсе 1–168 часов). Уменьшение срока сразу сокращает и очищает существующие артефакты; увеличение действует только на новые.
 
 ## Локальный API-шлюз
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,7 +17,7 @@
 
 ---
 
-> **升级：** 按 [`INSTALL.md`](INSTALL.md) 的版本化步骤操作。`0.6.3` 包含严格 Cordis 注入启动修复并正式支持 DSH `0.1.1-rc.2`；保留 profile、配置和凭据文件，更新后再重启一次现有 DSH Web 进程。`dsh-coding-oauth-core@0.1.0` 仍是共享 npm 依赖，不是需要单独安装的 DSH 插件。
+> **升级：** 按 [`INSTALL.md`](INSTALL.md) 的版本化步骤操作。`0.6.3` 新增默认关闭的 `codexImagesAnyModel` 开关。`0.6.2` 及之后版本已包含严格 Cordis 注入启动修复并正式支持 DSH `0.1.1-rc.2`；保留 profile、配置和凭据文件，更新后再重启一次现有 DSH Web 进程。`dsh-coding-oauth-core@0.1.0` 仍是共享 npm 依赖，不是需要单独安装的 DSH 插件。
 
 ---
 
@@ -182,7 +182,7 @@ DSH 主机在远端时优先使用设备码。浏览器/PKCE 登录会打开供�
 
 ## 可选能力
 
-八项开关默认全部**关闭**，打开后**立即生效**（无需重启）：`codexSearch`、`codexImages`、`codexImageEdits`、`codexImagesAnyModel`、`codexUsage`、`codexFast`、`grokImagineImage`、`grokImagineVideo`。数值控制为 `searchResults`（1–20，默认 5）、`imageCount`（1–4，默认 1）、`videoArtifactTtlMs`（1 小时–7 天，默认 7 天；界面以 1–168 小时显示）。降低视频保留时间会立即缩短并清理已有产物；提高只影响之后生成的产物。管理员也可在插件配置的 `capabilities` 下提供不含秘密的 composition 默认值；`coding-subscription-oauth` 设置区中的用户值会覆盖这层 base，省略时所有开关仍保持关闭。
+八项开关默认全部**关闭**，打开后**立即生效**（无需重启）：`codexSearch`、`codexImages`、`codexImageEdits`、`codexImagesAnyModel`、`codexUsage`、`codexFast`、`grokImagineImage`、`grokImagineVideo`。`codexImagesAnyModel` 仅放宽调用模型路由限制；仍要求已登录 Codex、开启 `codexImages`（编辑还需 edits 开关），并保留当前会话附件归属和编辑授权检查。数值控制为 `searchResults`（1–20，默认 5）、`imageCount`（1–4，默认 1）、`videoArtifactTtlMs`（1 小时–7 天，默认 7 天；界面以 1–168 小时显示）。降低视频保留时间会立即缩短并清理已有产物；提高只影响之后生成的产物。管理员也可在插件配置的 `capabilities` 下提供不含秘密的 composition 默认值；`coding-subscription-oauth` 设置区中的用户值会覆盖这层 base，省略时所有开关仍保持关闭。
 
 `codex-oauth-fast` 仅在**最新一次 live catalog** 标明至少有一个 `priority` 可用模型后才会出现。请求会发送 `service_tier: priority` 和路由提示。界面写的是 **已请求 Fast**，不保证延迟，也不保证上游会兑现。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Review of the post-`0.6.3` README surface found the upgrade callout still attributing the Cordis/DSH `0.1.1-rc.2` work to `0.6.3`, and the optional-capabilities inventory listing `codexImagesAnyModel` without the route-gate boundary that `INSTALL.md` already states.

## Scope

- `README.md` / `README.zh-CN.md` upgrade callouts: `0.6.3` = any-model; Cordis/DSH rc.2 = `0.6.2+`.
- Eight-switch sections in all nine READMEs: one-sentence any-model boundary.
- `INSTALL.md`: `0.6.2` → `0.6.3` upgrade bullet.
- `CHANGELOG.md` Unreleased Documentation entry.
- No version bump, no `src/` / `lib/` changes.

## Blast Radius

Readers of install/upgrade docs only. No runtime change.

## Verification

- Spot-checked EN/zh upgrade blurb and all nine eight-switch boundary sentences.
- `git diff main...HEAD --stat`: 11 files, docs only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-430b830b-a909-4bc0-ac02-df266cad520d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-430b830b-a909-4bc0-ac02-df266cad520d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

