### PR TITLE
chore(env): add Cloud Agent environment with DSH CLI

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "dsh-plugins-cloud",
+  "install": "export NVM_DIR=\"$HOME/.nvm\"\n[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"\nnvm install 22.22.2\nnvm alias default 22.22.2\nnvm use --delete-prefix 22.22.2 --silent || nvm use 22.22.2\nhash -r\nexport PATH=\"$NVM_DIR/versions/node/v22.22.2/bin:$PATH\"\nnode -v\ncorepack enable\ncorepack prepare pnpm@11.21.0 --activate\npnpm -v\nnpm install -g @deepseek-ai/dsh@0.1.1-rc.2\nmkdir -p \"$HOME/.dsh-cloud\"\nfor name in dsh-hub-oauth-gateway dsh-coding-subscription-oauth dsh-coding-remote-kit; do\n  for base in /workspace /agent/repos; do\n    if [ -f \"$base/$name/pnpm-lock.yaml\" ]; then\n      (cd \"$base/$name\" && pnpm install --frozen-lockfile)\n    fi\n  done\ndone\nif [ -f ./pnpm-lock.yaml ]; then pnpm install --frozen-lockfile; fi\ndsh --version\n",
+  "repositoryDependencies": [
+    "github.com/lninghaha/dsh-hub-oauth-gateway",
+    "github.com/lninghaha/dsh-coding-remote-kit"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.cursor/environment.json` for Cursor Cloud Agents: Node 22.22.2, pnpm 11.21.0, pinned `@deepseek-ai/dsh@0.1.1-rc.2`, isolated `$HOME/.dsh-cloud`, and sibling plugin installs.

## Validation
Draft build [`bld-20260902-f911697e-566b-4357-b924-106a50f8226c`](https://cursor.com/dashboard/cloud-agents/builds/bld-20260902-f911697e-566b-4357-b924-106a50f8226c) **SUCCEEDED**; fresh Cloud Agent verified `dsh --version=0.1.1-rc.2` and isolated `dsh web` HTTP 200.

Companion PRs: hub #26, remote-kit #7.